### PR TITLE
Fix assumption of numeric sorting of returned keys in bitstring

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ df.columns = ['cost', 'weight']
 
 bqm = knapsack_bqm(df['cost'], df['weight'], weight_capacity)
 
-sampler = LeapHybridSampler(profile='hss')
+sampler = LeapHybridSampler()
 sampleset = sampler.sample(bqm)
 var_names = sampleset.variables
 n_sols = sampleset.record.sample.shape[0]

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ import sys
 from dwave.system import LeapHybridSampler
 from math import log, ceil
 import dimod
-import re
 
 # From Andrew Lucas, NP-hard combinatorial problems as Ising spin glasses
 # Workshop on Classical and Quantum Optimization; ETH Zuerich - August 20, 2014
@@ -89,17 +88,16 @@ bqm = knapsack_bqm(df['cost'], df['weight'], weight_capacity)
 
 sampler = LeapHybridSampler()
 sampleset = sampler.sample(bqm)
-n_sols = sampleset.record.sample.shape[0]
-for i in range(n_sols):
+for sample, energy in zip(sampleset.record.sample, sampleset.record.energy):
 
     # Build solution from returned bitstring
     solution = []
-    for j0, j in enumerate(sampleset.record.sample[i]):
+    for this_bit_index, this_bit in enumerate(sample):
         # The x's indicate whether each object has been selected
-        if j == 1. and sampleset.variables[j0].startswith('x'):
+        this_var = sampleset.variables[this_bit_index]
+        if this_bit == 1. and this_var.startswith('x'):
             # Indexing of the weights is different than the bitstring;
             # cannot guarantee any ordering of the bitstring, but the
             # weights are numerically sorted
-            a1 = re.search("x(\d+)", sampleset.variables[j0])
-            solution.append(df['weight'][int(a1.group(1))])
-    print("Found solution {} at energy {}.".format(solution, sampleset.record.energy[i]))
+            solution.append(df['weight'][int(this_var[1:])])
+    print("Found solution {} at energy {}.".format(solution, energy))

--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ for sample, energy in zip(sampleset.record.sample, sampleset.record.energy):
     for this_bit_index, this_bit in enumerate(sample):
         # The x's indicate whether each object has been selected
         this_var = sampleset.variables[this_bit_index]
-        if this_bit == 1. and this_var.startswith('x'):
+        if this_bit and this_var.startswith('x'):
             # Indexing of the weights is different than the bitstring;
             # cannot guarantee any ordering of the bitstring, but the
             # weights are numerically sorted

--- a/main.py
+++ b/main.py
@@ -90,8 +90,10 @@ df.columns = ['cost', 'weight']
 
 bqm = knapsack_bqm(df['cost'], df['weight'], weight_capacity)
 
-sampler = LeapHybridSampler()
+sampler = LeapHybridSampler(profile='hss')
 sampleset = sampler.sample(bqm)
-solution = [df['weight'][i] for i in range(len(df['weight'])) if sampleset.record.sample[0][i] == 1.]
-
-print("Found solution {} at energy {}.".format(solution, sampleset.first.energy))
+var_names = sampleset.variables
+n_sols = sampleset.record.sample.shape[0]
+for i in range(n_sols):
+    solution = [df['weight'][j0] for j0, j in enumerate(sampleset.record.sample[i]) if j == 1. and var_names[j0].startswith('x')]
+    print("Found solution {} at energy {}.".format(solution, sampleset.record.energy[i]))

--- a/main.py
+++ b/main.py
@@ -23,6 +23,10 @@ import dimod
 # based on Lucas, Frontiers in Physics _2, 5 (2014)
 
 
+def get_label(lbl, i):
+    return lbl + str(i).zfill(2)
+
+
 def knapsack_bqm(costs, weights, weight_capacity):
 
     costs = costs
@@ -50,28 +54,28 @@ def knapsack_bqm(costs, weights, weight_capacity):
 
     # Hamiltonian xi-xi terms
     for k in range(x_size):
-        bqm.set_linear('x' + str(k), lagrange * (weights[k]**2) - costs[k])
+        bqm.set_linear(get_label('x', k), lagrange * (weights[k]**2) - costs[k])
 
     # Hamiltonian xi-xj terms
     for i in range(x_size):
         for j in range(i + 1, x_size):
-            key = ('x' + str(i), 'x' + str(j))
+            key = (get_label('x', i), get_label('x', j))
             bqm.quadratic[key] = 2 * lagrange * weights[i] * weights[j]
 
     # Hamiltonian y-y terms
     for k in range(max_y_index):
-        bqm.set_linear('y' + str(k), lagrange * (y[k]**2))
+        bqm.set_linear(get_label('y', k), lagrange * (y[k]**2))
 
     # Hamiltonian yi-yj terms
     for i in range(max_y_index):
         for j in range(i + 1, max_y_index):
-            key = ('y' + str(i), 'y' + str(j))
+            key = (get_label('y', i), get_label('y', j))
             bqm.quadratic[key] = 2 * lagrange * y[i] * y[j]
 
     # Hamiltonian x-y terms
     for i in range(x_size):
         for j in range(max_y_index):
-            key = ('x' + str(i), 'y' + str(j))
+            key = (get_label('x', i), get_label('y', j))
             bqm.quadratic[key] = -2 * lagrange * weights[i] * y[j]
 
     return bqm


### PR DESCRIPTION
The previous version had a problem, when the number of items considered by the program (the number of books, cartons, etc. for the knapsack, stored in the input data file) went from 9 to 10. We saw that the energy of the solution appeared to be right, but the objects collected in the knapsack exceeded the maximum weight allowed. 
It turned out that what was happening was that the bitstrings were returned, by the Hybrid Solver, with keys sorted alphabetically. The code was figuring out which bits were turned on - and then looking up the weights of those selected items. The problem was that the list of weights was not sorted alphabetically - it was sorted numerically. It made sense that the trouble occurred after the 10th item entered the picture:
0, 1, 10, 11, 12..., 2, 3...

The fix I chose was to not assume any particular order in the bitstring.
We do know the names of the variables being returned (that is in the sampleset) - and so therefore we know which items are selected. What we have to do is extract the "integer index" of each item that is selected - which can then be used as the key in the weights list. In other words, 'x62' might be the third item turned on in the bitstring, but it is weight #62. 

Another way to explain this:
The bitstring dict cannot be assumed to have any particular order of keys.
The previous version assumed it could be enumerated.
Instead, we need to look at which bits are turned on, and extract the original indices, and then index into the weights list. 

Closes #4 